### PR TITLE
6_Конфигурация и профили	

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,6 +19,10 @@ repositories {
 
 dependencies {
 	implementation("org.springframework.boot:spring-boot-starter")
+	implementation("org.springframework.boot:spring-boot-starter-thymeleaf")
+	implementation("org.projectlombok:lombok:1.18.30")
+	compileOnly("org.projectlombok:lombok")
+	annotationProcessor("org.projectlombok:lombok")
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }

--- a/src/main/java/org/javaspringcourse/config/MinecraftServerStartConfig.java
+++ b/src/main/java/org/javaspringcourse/config/MinecraftServerStartConfig.java
@@ -1,0 +1,48 @@
+package org.javaspringcourse.config;
+
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.javaspringcourse.config.property.MinecraftServerStartProp;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+@Log4j2
+@Configuration
+@EnableConfigurationProperties(MinecraftServerStartProp.class)
+@RequiredArgsConstructor
+public class MinecraftServerStartConfig {
+    private final MinecraftServerStartProp minecraftServerStartProp;
+
+    @Bean
+    @Profile("test")
+    public String testServerChecker() {
+        log.info("Running testServerChecker...");
+        return "testServerChecker";
+    }
+
+    @Bean
+    @ConditionalOnBean(name = "testServerChecker")
+    public String testServerProfiler() {
+        log.info("Running testServerProfiler...");
+        return "testServerChecker";
+    }
+
+    @Bean
+    @ConditionalOnExpression("'${server.env-var}' != 'default'")
+    public String specialServerMode() {
+        log.info("Running specialServerMode...");
+        log.warn("GEORGE DROID ©NEGROTECH 2077 joined the server.");
+        return "specialServerMode";
+    }
+
+    @PostConstruct
+    public void init() {
+        log.info("Server Name: {}", minecraftServerStartProp.getName());
+        log.info("Server Params: {}", minecraftServerStartProp.getStartParams());
+    }
+}

--- a/src/main/java/org/javaspringcourse/config/property/MinecraftServerStartProp.java
+++ b/src/main/java/org/javaspringcourse/config/property/MinecraftServerStartProp.java
@@ -1,0 +1,13 @@
+package org.javaspringcourse.config.property;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.util.List;
+
+@Data
+@ConfigurationProperties(prefix = "server.start")
+public class MinecraftServerStartProp {
+    String name;
+    List<String> startParams;
+}

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -1,0 +1,8 @@
+server:
+  start:
+    name: svo-craft-dev
+    startParams:
+      - debug
+      - infiniteWar
+      - nobodyWins
+  env-var: ${env-var:default}

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -1,0 +1,7 @@
+server:
+  start:
+    name: svo-craft-dev
+    startParams:
+      - dogovornyachokWillBe
+      - trumpWins
+  env-var: ${env-var:specialVal}

--- a/src/main/resources/application-test.yaml
+++ b/src/main/resources/application-test.yaml
@@ -1,0 +1,8 @@
+server:
+  start:
+    name: svo-craft-dev
+    startParams:
+      - debug
+      - checkDogovornyachok
+      - nobodyWins
+  env-var: ${env-var:default}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=java-spring-course

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,0 +1,3 @@
+spring:
+  application:
+    name: java-spring-course


### PR DESCRIPTION
Студент: Аптуликсанов Руслан Германович
Преподаватель: Никита Иванов

- [x] Создать 3 профиля - dev (`application-dev.yaml`), test (`application-test.yaml`), prod (`application-prod.yaml`), каждый из которых будет включать в себя: 
    - [x] конфиг с листом из нескольких значений (`startParams`)
    - [x] название приложения (`name`)
    - [x] конфиг с переменной окружения, по дефолту значение - default (`env-var`)
- [x] 3 бина: 
    - [x] один создается, только если профиль test (`testServerChecker`), 
    - [x] другой, если существует первый бин (`testServerProfiler`), 
    - [x] третий, если в конфиге EXAMPLE_TEST (env var) не “default” (тут в идеале со скриншотом) (`specialServerMode`)

![изображение](https://github.com/user-attachments/assets/4d543caf-63d2-44aa-be16-ccd3b369fc97)
